### PR TITLE
Add containerId prop and env site key default for captcha

### DIFF
--- a/components/SplatCaptcha.tsx
+++ b/components/SplatCaptcha.tsx
@@ -5,11 +5,18 @@ import Script from 'next/script';
 type TurnstileTheme = 'light' | 'dark' | 'auto';
 
 export interface SplatCaptchaProps {
-  siteKey: string;                 // Required Cloudflare Turnstile site key
-  action?: string;                 // Optional action name
-  cData?: string;                  // Optional custom data
-  theme?: TurnstileTheme;          // Theme, defaults to 'dark'
-  className?: string;              // Wrapper class
+  /**
+   * Cloudflare Turnstile site key.  If not provided, falls back to the
+   * `NEXT_PUBLIC_CLOUDFLARE_SITE_KEY` environment variable so most call sites
+   * don't need to pass it explicitly.
+   */
+  siteKey?: string;
+  action?: string;
+  cData?: string;
+  theme?: TurnstileTheme;
+  className?: string;
+  /** Optional id applied to the containing div. */
+  containerId?: string;
   onVerify: (token: string) => void;
   onExpire?: () => void;
   onError?: () => void;
@@ -24,16 +31,17 @@ declare global {
 }
 
 export default function SplatCaptcha({
-  siteKey,
+  siteKey = process.env.NEXT_PUBLIC_CLOUDFLARE_SITE_KEY || '',
   action,
   cData,
   theme = 'dark',
   className,
+  containerId,
   onVerify,
   onExpire,
   onError,
 }: SplatCaptchaProps) {
-  const id = useId();
+  const autoId = useId();
   const widgetRef = useRef<HTMLDivElement | null>(null);
   const [widgetId, setWidgetId] = useState<string | null>(null);
 
@@ -79,7 +87,7 @@ export default function SplatCaptcha({
         onLoad={render}
       />
       <div
-        id={`splat-turnstile-${id}`}
+        id={containerId || `splat-turnstile-${autoId}`}
         ref={widgetRef}
         className={className}
         // keep an explicit min-height so layout doesn't jump

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,9 @@
         "@sentry/nextjs": "^10.2.0",
         "@sentry/react": "^10.2.0",
         "@supabase/supabase-js": "^2.52.0",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.1.11",
         "axios": "^1.11.0",
+        "lightningcss-linux-x64-gnu": "1.30.1",
         "lucide-react": "^0.536.0",
         "micro": "^10.0.1",
         "next": "15.4.1",
@@ -2844,6 +2846,21 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.11.tgz",
+      "integrity": "sha512-YW6sblI7xukSD2TdbbaeQVDysIm/UPJtObHJHKxDEcW2exAtY47j52f8jZXkqE1krdnkhCMGqP3dbniu1Te2Fg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "os": [
+        "linux"
       ],
       "engines": {
         "node": ">= 10"
@@ -8064,6 +8081,25 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
+      "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "os": [
+        "linux"
       ],
       "engines": {
         "node": ">= 12.0.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "resend": "^4.7.0",
-    "stripe": "^18.4.0"
+    "stripe": "^18.4.0",
+    "lightningcss-linux-x64-gnu": "1.30.1",
+    "@tailwindcss/oxide-linux-x64-gnu": "4.1.11"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.0.0",


### PR DESCRIPTION
## Summary
- allow SplatCaptcha to accept a `containerId` and optional site key
- default site key from `NEXT_PUBLIC_CLOUDFLARE_SITE_KEY`
- include native Linux bindings for Tailwind and Lightning CSS so the build can find required modules

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689857ce2428832f89dff607cae3214d