### PR TITLE
Fix form submissions with Supabase and Turnstile

### DIFF
--- a/pages/api/ambassador.ts
+++ b/pages/api/ambassador.ts
@@ -36,9 +36,11 @@ export default splatApiHandler(async (req: NextApiRequest, res: NextApiResponse)
   const captchaOK = await verifyCaptcha(body.captchaToken, req.headers["x-forwarded-for"] as string);
   if (!captchaOK) return sendError(res, 403, "CAPTCHA verification failed");
 
-  // 3) Database Insert
+  // 3) Database Insert (omit captchaToken and ensure correct types)
+  const { captchaToken, number_of_followers, ...rest } = body;
   const insertPayload = {
-    ...body,
+    ...rest,
+    number_of_followers: number_of_followers ? Number(number_of_followers) : null,
     status: "pending",
     email: body.email.trim().toLowerCase(),
   };
@@ -68,5 +70,5 @@ export default splatApiHandler(async (req: NextApiRequest, res: NextApiResponse)
   }
 
   // 5) Return Success + Redirect Instruction
-  return sendSuccess(res, "Application submitted. Redirecting now...", { redirectTo: "/thank-you" });
+  return sendSuccess(res, "Application submitted. Redirecting now...", undefined, "/thank-you");
 });

--- a/pages/api/signup.ts
+++ b/pages/api/signup.ts
@@ -4,14 +4,14 @@ import { createClient } from "@supabase/supabase-js";
 import { Resend } from "resend";
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_KEY!;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 const RESEND_API_KEY = process.env.RESEND_API_KEY!;
 const CLOUDFLARE_SECRET_KEY = process.env.CLOUDFLARE_SECRET_KEY!;
 
 const FROM_EMAIL = "SPL@T <noreply@usesplat.com>";
 const BRAND_NAME = process.env.BRAND_NAME || "SPL@T";
 
-const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 const resend = new Resend(RESEND_API_KEY);
 
 const isValidEmail = (v: string) => /.+@.+\..+/.test(v.trim()) && v.trim().length <= 320;

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -51,12 +51,16 @@ export default function SignupPage() {
           marketingConsent,
           turnstileToken,
           referralCode: referralCode ? referralCode.toUpperCase() : null,
+          signupSource: "website",
         }),
       });
 
-      if (res.ok || res.status === 409) return router.push("/thank-you");
-
       const data = await res.json().catch(() => ({}));
+      if (res.ok || res.status === 409) {
+        const dest = data?.redirectTo || "/thank-you";
+        return router.push(dest);
+      }
+
       const message: string = data?.error || "Something went wrong.";
       if (/captcha|token|turnstile/i.test(message)) {
         setError("Captcha check failed — try again.");


### PR DESCRIPTION
## Summary
- Ensure ambassador API parses follower count and omits CAPTCHA token before insert
- Use service role key in signup API so signups persist and redirect

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b3233ce910832f97942a35fda5eae7